### PR TITLE
Fixed no babel config error in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "eslint.workingDirectories": [{ "mode": "auto" }] }


### PR DESCRIPTION
For whatever reason ESLint in Visual Studio Code wasn't able to resolve the Babel config file, now it should work fine.