### PR TITLE
Fixed name and email fields in dl4se-website's package.json

### DIFF
--- a/dl4se-website/package.json
+++ b/dl4se-website/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "author": {
-    "email": "Ozren Dabić",
-    "name": "dabico@usi.ch",
+    "name": "Ozren Dabić",
+    "email": "dabico@usi.ch",
     "url": "https://dabico.github.io/"
   },
   "license": "MIT",


### PR DESCRIPTION
I noticed that in the `dl4se-website`'s package.json, the name and email fields were swapped.