### PR TITLE
Fix bugs and enhance `organisation` autocomplete functionalities

### DIFF
--- a/.idea/runConfigurations/GET__organisation.xml
+++ b/.idea/runConfigurations/GET__organisation.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="GET /organisation" type="HttpClient.HttpRequestRunConfigurationType" factoryName="HTTP Request" folderName="/organisation" path="$PROJECT_DIR$/http/OrganisationController.http" requestIdentifier="GET /organisation" runType="Run single request">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/GET__organisation__domain_.xml
+++ b/.idea/runConfigurations/GET__organisation__domain_.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="GET /organisation/{domain}" type="HttpClient.HttpRequestRunConfigurationType" factoryName="HTTP Request" folderName="/organisation" path="$PROJECT_DIR$/http/OrganisationController.http" index="2" requestIdentifier="GET /organisation/{domain}" runType="Run single request">
+    <method v="2" />
+  </configuration>
+</component>

--- a/dl4se-server/pom.xml
+++ b/dl4se-server/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>spring-cloud-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-openfeign</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/config/FeignConfig.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/config/FeignConfig.java
@@ -1,0 +1,9 @@
+package ch.usi.si.seart.server.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "ch.usi.si.seart.server.feign")
+public class FeignConfig {
+}

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/config/SecurityConfig.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 .hasRole("ADMIN")
                 .antMatchers(
                         "/",
+                        "/organisation",
                         "/user/login",
                         "/user/register",
                         "/user/verify",

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/config/SecurityConfig.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 .antMatchers(
                         "/",
                         "/organisation",
+                        "/organisation/*",
                         "/user/login",
                         "/user/register",
                         "/user/verify",

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
@@ -1,44 +1,34 @@
 package ch.usi.si.seart.server.controller;
 
+import ch.usi.si.seart.server.feign.UniversityDomainsListClient;
 import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.net.URI;
 
 @RestController
 @RequestMapping("/organisation")
+@AllArgsConstructor(onConstructor_ = @Autowired)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class OrganisationController {
 
+    UniversityDomainsListClient universityDomainsListClient;
+
     @GetMapping
-    public ResponseEntity<?> getOrganisations(
+    public ResponseEntity<?> organisations(
             @RequestParam(required = false, defaultValue = "")
             String name,
             Pageable pageable
     ) {
-        String base = "http://universities.hipolabs.com/search";
-        URI uri = UriComponentsBuilder.fromHttpUrl(base)
-                .queryParam("name", name)
-                .queryParam("limit", pageable.getPageSize())
-                .build()
-                .toUri();
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<?> response = restTemplate.exchange(
-                uri, HttpMethod.GET, entity, JsonNode.class
-        );
-        return ResponseEntity.ok(response.getBody());
+        int limit = pageable.getPageSize();
+        JsonNode response = universityDomainsListClient.search(name, limit);
+        return ResponseEntity.ok(response);
     }
 }

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
@@ -1,0 +1,44 @@
+package ch.usi.si.seart.server.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/organisation")
+public class OrganisationController {
+
+    @GetMapping
+    public ResponseEntity<?> getOrganisations(
+            @RequestParam(required = false, defaultValue = "")
+            String name,
+            Pageable pageable
+    ) {
+        String base = "http://universities.hipolabs.com/search";
+        URI uri = UriComponentsBuilder.fromHttpUrl(base)
+                .queryParam("name", name)
+                .queryParam("limit", pageable.getPageSize())
+                .build()
+                .toUri();
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<?> response = restTemplate.exchange(
+                uri, HttpMethod.GET, entity, JsonNode.class
+        );
+        return ResponseEntity.ok(response.getBody());
+    }
+}

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/controller/OrganisationController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +31,12 @@ public class OrganisationController {
         int limit = pageable.getPageSize();
         JsonNode response = universityDomainsListClient.search(name, limit);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{domain}")
+    public ResponseEntity<?> organisations(@PathVariable String domain) {
+        JsonNode response = universityDomainsListClient.search(domain);
+        JsonNode result = response.get(0);
+        return ResponseEntity.ok(result);
     }
 }

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/feign/UniversityDomainsListClient.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/feign/UniversityDomainsListClient.java
@@ -1,0 +1,14 @@
+package ch.usi.si.seart.server.feign;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "university-domains-list", url = "http://universities.hipolabs.com")
+public interface UniversityDomainsListClient {
+
+    @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
+    JsonNode search(@RequestParam("name") String name, @RequestParam("limit") Integer limit);
+}

--- a/dl4se-server/src/main/java/ch/usi/si/seart/server/feign/UniversityDomainsListClient.java
+++ b/dl4se-server/src/main/java/ch/usi/si/seart/server/feign/UniversityDomainsListClient.java
@@ -10,5 +10,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UniversityDomainsListClient {
 
     @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
+    JsonNode search(@RequestParam("domain") String domain);
+
+    @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
     JsonNode search(@RequestParam("name") String name, @RequestParam("limit") Integer limit);
 }

--- a/dl4se-website/src/components/FormAutoComplete.vue
+++ b/dl4se-website/src/components/FormAutoComplete.vue
@@ -101,9 +101,14 @@ export default {
       default: true,
     },
   },
-  watch: {
-    input() {
-      this.$emit("input", this.input);
+  computed: {
+    input: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit("input", value);
+      },
     },
   },
   mounted() {
@@ -128,11 +133,6 @@ export default {
   },
   beforeDestroy() {
     Autocomplete.getInstance(this.$el).dispose();
-  },
-  data() {
-    return {
-      input: this.value,
-    };
   },
 };
 </script>

--- a/dl4se-website/src/mixins/organisationsMixin.js
+++ b/dl4se-website/src/mixins/organisationsMixin.js
@@ -1,0 +1,7 @@
+export default {
+  computed: {
+    organisationsURL() {
+      return `${process.env.VUE_APP_API_BASE_URL}/organisation`;
+    },
+  },
+};

--- a/dl4se-website/src/views/ProfileView.vue
+++ b/dl4se-website/src/views/ProfileView.vue
@@ -96,10 +96,10 @@
                         <b-form-auto-complete
                           type="text"
                           v-model.trim="form.organisation"
-                          server="http://universities.hipolabs.com/search"
+                          :server="organisationsURL"
                           query-param="name"
                           :debounce-time="250"
-                          :server-params="{ limit: 10 }"
+                          :server-params="{ size: 10 }"
                           :response-mapper="responseMapper"
                           :state="!v$.form.organisation.$invalid"
                           class="mb-3"
@@ -125,7 +125,7 @@
 <script>
 import getRandomName from "namesgenerator";
 import useVuelidate from "@vuelidate/core";
-import { email, required, sameAs } from "@vuelidate/validators";
+import { email, required } from "@vuelidate/validators";
 import { uid } from "@/validators";
 import routerMixin from "@/mixins/routerMixin";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
@@ -155,6 +155,9 @@ export default {
       const invalid = this.v$.form.organisation.$invalid;
       const changed = this.form.organisation !== this.user.organisation;
       return !invalid && changed;
+    },
+    organisationsURL() {
+      return `${process.env.VUE_APP_API_BASE_URL}/organisation`;
     },
   },
   methods: {

--- a/dl4se-website/src/views/ProfileView.vue
+++ b/dl4se-website/src/views/ProfileView.vue
@@ -128,13 +128,14 @@ import useVuelidate from "@vuelidate/core";
 import { email, required } from "@vuelidate/validators";
 import { uid } from "@/validators";
 import routerMixin from "@/mixins/routerMixin";
+import organisationsMixin from "@/mixins/organisationsMixin";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
 import BFormSubmit from "@/components/FormSubmit";
 import BIconIdenticon from "@/components/IconIdenticon";
 import BFormAutoComplete from "@/components/FormAutoComplete.vue";
 
 export default {
-  mixins: [routerMixin, bootstrapMixin],
+  mixins: [routerMixin, organisationsMixin, bootstrapMixin],
   components: {
     BFormAutoComplete,
     BFormSubmit,
@@ -155,9 +156,6 @@ export default {
       const invalid = this.v$.form.organisation.$invalid;
       const changed = this.form.organisation !== this.user.organisation;
       return !invalid && changed;
-    },
-    organisationsURL() {
-      return `${process.env.VUE_APP_API_BASE_URL}/organisation`;
     },
   },
   methods: {

--- a/dl4se-website/src/views/ProfileView.vue
+++ b/dl4se-website/src/views/ProfileView.vue
@@ -99,7 +99,7 @@
                           :server="organisationsURL"
                           query-param="name"
                           :debounce-time="250"
-                          :server-params="{ size: 10 }"
+                          :server-params="{ size: 5 }"
                           :response-mapper="responseMapper"
                           :state="!v$.form.organisation.$invalid"
                           class="mb-3"

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -116,20 +116,16 @@ import useVuelidate from "@vuelidate/core";
 import { email, required, sameAs } from "@vuelidate/validators";
 import { password } from "@/validators";
 import routerMixin from "@/mixins/routerMixin";
+import organisationsMixin from "@/mixins/organisationsMixin";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
 import BFormAutoComplete from "@/components/FormAutoComplete";
 import BFormSubmit from "@/components/FormSubmit";
 
 export default {
-  mixins: [routerMixin, bootstrapMixin],
+  mixins: [routerMixin, organisationsMixin, bootstrapMixin],
   components: {
     BFormAutoComplete,
     BFormSubmit,
-  },
-  computed: {
-    organisationsURL() {
-      return `${process.env.VUE_APP_API_BASE_URL}/organisation`;
-    },
   },
   methods: {
     responseMapper(json) {

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -80,7 +80,7 @@
                 :server="organisationsURL"
                 query-param="name"
                 :debounce-time="250"
-                :server-params="{ size: 10 }"
+                :server-params="{ size: 5 }"
                 :response-mapper="responseMapper"
                 :disabled="submitted"
                 :state="v$.form.organisation.$dirty ? !v$.form.organisation.$invalid : null"

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -19,6 +19,7 @@
               :state="v$.form.email.$dirty ? !v$.form.email.$invalid : null"
               placeholder="example@email.com"
               autofocus
+              @blur="autofillOrganisation"
             />
           </b-form-group>
         </b-form-row>
@@ -130,6 +131,15 @@ export default {
   methods: {
     responseMapper(json) {
       return json.map((item) => item.name);
+    },
+    async autofillOrganisation() {
+      const validator = this.v$.form.email;
+      const dirty = validator.$dirty;
+      const valid = !validator.$invalid;
+      if (!dirty || !valid) return;
+      const email = validator.$model;
+      const [_, domain] = email.split("@");
+      this.form.organisation = await this.$http.get(`/organisation/${domain}`).then(({ data }) => data?.name);
     },
     async register() {
       this.submitted = true;

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -139,7 +139,9 @@ export default {
       if (!dirty || !valid) return;
       const email = validator.$model;
       const [_, domain] = email.split("@");
-      this.form.organisation = await this.$http.get(`/organisation/${domain}`).then(({ data }) => data?.name);
+      const organisation = await this.$http.get(`/organisation/${domain}`).then(({ data }) => data?.name);
+      if (!organisation) return;
+      this.form.organisation = organisation;
     },
     async register() {
       this.submitted = true;

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -77,10 +77,10 @@
                 name="organisation"
                 type="text"
                 v-model.trim="form.organisation"
-                server="http://universities.hipolabs.com/search"
+                :server="organisationsURL"
                 query-param="name"
                 :debounce-time="250"
-                :server-params="{ limit: 10 }"
+                :server-params="{ size: 10 }"
                 :response-mapper="responseMapper"
                 :disabled="submitted"
                 :state="v$.form.organisation.$dirty ? !v$.form.organisation.$invalid : null"
@@ -125,6 +125,11 @@ export default {
   components: {
     BFormAutoComplete,
     BFormSubmit,
+  },
+  computed: {
+    organisationsURL() {
+      return `${process.env.VUE_APP_API_BASE_URL}/organisation`;
+    },
   },
   methods: {
     responseMapper(json) {

--- a/http/OrganisationController.http
+++ b/http/OrganisationController.http
@@ -1,2 +1,5 @@
 ### GET /organisation
 GET localhost:8080/api/organisation?name=university+of+california
+
+### GET /organisation/{domain}
+GET localhost:8080/api/organisation/berkeley.edu

--- a/http/OrganisationController.http
+++ b/http/OrganisationController.http
@@ -1,0 +1,2 @@
+### GET /organisation
+GET localhost:8080/api/organisation?name=university+of+california


### PR DESCRIPTION
Rather than calling the `university-domains-list` API directly, we instead use a Feign client on our server as an interface to that endpoint. This effectively circumnavigates the problem of accessing HTTP resources from an HTTPS front-end. The registration form was also enhanced to autofill the user organisation based on the provided email domain.