### PR TITLE
Improve `lodash` usage

### DIFF
--- a/dl4se-website/src/main.js
+++ b/dl4se-website/src/main.js
@@ -11,7 +11,6 @@ import VueAxios from "vue-axios";
 import VueScreen from "vue-screen";
 import VueScrollTo from "vue-scrollto";
 import { UnheadPlugin as VueUnhead } from "@unhead/vue/vue2";
-import _ from "lodash";
 import { BootstrapVue, BootstrapVueIcons } from "bootstrap-vue";
 import "aos/dist/aos.css";
 import "@/assets/styles/style.sass";
@@ -27,8 +26,6 @@ Vue.use(VueScreen, "bootstrap");
 Vue.use(VueScrollTo);
 Vue.use(BootstrapVue);
 Vue.use(BootstrapVueIcons);
-
-Vue.prototype.$_ = _;
 
 Vue.component("fragment", Fragment);
 

--- a/dl4se-website/src/mixins/formatterMixin.js
+++ b/dl4se-website/src/mixins/formatterMixin.js
@@ -1,3 +1,5 @@
+import { startCase } from "lodash";
+
 export default {
   methods: {
     format(value, decimals = 2, k = 1000, units = ["", "K", "M", "B", "T"]) {
@@ -22,7 +24,7 @@ export default {
       return this.format(value, 2, 1024, ["B", "KB", "MB", "GB", "TB", "PB"]);
     },
     toTitle(value) {
-      return this.$_.startCase(this.$_.lowerCase(this.$_.defaultTo(value, "???")));
+      return startCase(value?.toLowerCase() ?? "???");
     },
   },
 };

--- a/dl4se-website/src/views/DashboardView.vue
+++ b/dl4se-website/src/views/DashboardView.vue
@@ -189,6 +189,7 @@
 </template>
 
 <script>
+import { indexOf, startCase } from "lodash";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
 import formatterMixin from "@/mixins/formatterMixin";
 import routerMixin from "@/mixins/routerMixin";
@@ -234,14 +235,14 @@ export default {
         })
         .sort(([key1, value1], [key2, value2]) => {
           const order = ["boolean", "number", "string", "object"];
-          const type1 = this.$_.indexOf(order, typeof value1);
-          const type2 = this.$_.indexOf(order, typeof value2);
+          const type1 = indexOf(order, typeof value1);
+          const type2 = indexOf(order, typeof value2);
           if (type1 < type2) return 1;
           if (type1 > type2) return -1;
           else return key2.localeCompare(key1);
         })
         .map(([key, value]) => {
-          const label = this.$_.startCase(key);
+          const label = startCase(key);
           switch (typeof value) {
             case "boolean":
               return `- ${label}`;


### PR DESCRIPTION
Rather than importing a global, which just ends up increasing our build size while remaining mostly unused, we instead only import utilities as needed.