### PR TITLE
Clean up directive definitions

### DIFF
--- a/dl4se-website/src/directives/index.js
+++ b/dl4se-website/src/directives/index.js
@@ -1,1 +1,1 @@
-export { default as vAos } from "./v-aos";
+export { default as VAos } from "./v-aos";

--- a/dl4se-website/src/directives/index.js
+++ b/dl4se-website/src/directives/index.js
@@ -1,0 +1,3 @@
+import vAos from "./v-aos";
+
+export default { vAos };

--- a/dl4se-website/src/directives/index.js
+++ b/dl4se-website/src/directives/index.js
@@ -1,1 +1,1 @@
-export { default as VAos } from "./v-aos";
+export * from "./v-aos";

--- a/dl4se-website/src/directives/index.js
+++ b/dl4se-website/src/directives/index.js
@@ -1,3 +1,1 @@
-import vAos from "./v-aos";
-
-export default { vAos };
+export { default as vAos } from "./v-aos";

--- a/dl4se-website/src/directives/v-aos.js
+++ b/dl4se-website/src/directives/v-aos.js
@@ -1,4 +1,4 @@
-export default (el, binding) => {
+export const VAos = (el, binding) => {
   const config = binding.value || {};
   const modifiers = binding.modifiers || {};
   Object.assign(el.dataset, {

--- a/dl4se-website/src/directives/v-aos.js
+++ b/dl4se-website/src/directives/v-aos.js
@@ -1,14 +1,14 @@
 export default (el, binding) => {
   const config = binding.value || {};
   const modifiers = binding.modifiers || {};
-  Object.entries({
-    "data-aos": config.animation,
-    "data-aos-offset": `${config.offset ?? 120}`,
-    "data-aos-delay": `${config.delay ?? 0}`,
-    "data-aos-duration": `${config.duration ?? 400}`,
-    "data-aos-easing": config.easing || "ease",
-    "data-aos-anchor-placement": config.anchorPlacement || "top-bottom",
-    "data-aos-once": `${!!modifiers.once}`,
-    "data-aos-mirror": `${!!modifiers.mirror}`,
-  }).forEach(([key, value]) => el.setAttribute(key, value));
+  Object.assign(el.dataset, {
+    aos: config.animation,
+    aosOffset: `${config.offset ?? 120}`,
+    aosDelay: `${config.delay ?? 0}`,
+    aosDuration: `${config.duration ?? 400}`,
+    aosEasing: config.easing || "ease",
+    aosAnchorPlacement: config.anchorPlacement || "top-bottom",
+    aosOnce: `${!!modifiers.once}`,
+    aosMirror: `${!!modifiers.mirror}`,
+  });
 };

--- a/dl4se-website/src/directives/v-aos.js
+++ b/dl4se-website/src/directives/v-aos.js
@@ -1,0 +1,14 @@
+export default (el, binding) => {
+  const config = binding.value || {};
+  const modifiers = binding.modifiers || {};
+  Object.entries({
+    "data-aos": config.animation,
+    "data-aos-offset": `${config.offset ?? 120}`,
+    "data-aos-delay": `${config.delay ?? 0}`,
+    "data-aos-duration": `${config.duration ?? 400}`,
+    "data-aos-easing": config.easing || "ease",
+    "data-aos-anchor-placement": config.anchorPlacement || "top-bottom",
+    "data-aos-once": `${!!modifiers.once}`,
+    "data-aos-mirror": `${!!modifiers.mirror}`,
+  }).forEach(([key, value]) => el.setAttribute(key, value));
+};

--- a/dl4se-website/src/main.js
+++ b/dl4se-website/src/main.js
@@ -6,8 +6,8 @@ import App from "@/App";
 import router from "@/router";
 import store from "@/store";
 import axios from "@/axios";
-import directives from "@/directives";
 import unhead from "@/unhead";
+import { vAos } from "@/directives";
 import VueAxios from "vue-axios";
 import VueScreen from "vue-screen";
 import VueScrollTo from "vue-scrollto";
@@ -31,7 +31,7 @@ Vue.use(BootstrapVueIcons);
 Vue.component("fragment", Fragment);
 
 Vue.prototype.$AOS = AOS;
-Vue.directive("aos", directives.vAos);
+Vue.directive("aos", vAos);
 
 new Vue({
   router,

--- a/dl4se-website/src/main.js
+++ b/dl4se-website/src/main.js
@@ -7,7 +7,7 @@ import router from "@/router";
 import store from "@/store";
 import axios from "@/axios";
 import unhead from "@/unhead";
-import { vAos } from "@/directives";
+import { VAos } from "@/directives";
 import VueAxios from "vue-axios";
 import VueScreen from "vue-screen";
 import VueScrollTo from "vue-scrollto";
@@ -31,7 +31,7 @@ Vue.use(BootstrapVueIcons);
 Vue.component("fragment", Fragment);
 
 Vue.prototype.$AOS = AOS;
-Vue.directive("aos", vAos);
+Vue.directive("aos", VAos);
 
 new Vue({
   router,

--- a/dl4se-website/src/main.js
+++ b/dl4se-website/src/main.js
@@ -6,6 +6,7 @@ import App from "@/App";
 import router from "@/router";
 import store from "@/store";
 import axios from "@/axios";
+import directives from "@/directives";
 import unhead from "@/unhead";
 import VueAxios from "vue-axios";
 import VueScreen from "vue-screen";
@@ -30,20 +31,7 @@ Vue.use(BootstrapVueIcons);
 Vue.component("fragment", Fragment);
 
 Vue.prototype.$AOS = AOS;
-Vue.directive("aos", (el, binding) => {
-  const config = binding.value || {};
-  const modifiers = binding.modifiers || {};
-  Object.entries({
-    "data-aos": config.animation,
-    "data-aos-offset": `${config.offset ?? 120}`,
-    "data-aos-delay": `${config.delay ?? 0}`,
-    "data-aos-duration": `${config.duration ?? 400}`,
-    "data-aos-easing": config.easing || "ease",
-    "data-aos-anchor-placement": config.anchorPlacement || "top-bottom",
-    "data-aos-once": `${!!modifiers.once}`,
-    "data-aos-mirror": `${!!modifiers.mirror}`,
-  }).forEach(([key, value]) => el.setAttribute(key, value));
-});
+Vue.directive("aos", directives.vAos);
 
 new Vue({
   router,

--- a/dl4se-website/src/main.js
+++ b/dl4se-website/src/main.js
@@ -31,19 +31,18 @@ Vue.component("fragment", Fragment);
 
 Vue.prototype.$AOS = AOS;
 Vue.directive("aos", (el, binding) => {
-  const config = binding.value;
-  const modifiers = binding.modifiers;
-
-  el.setAttribute("data-aos", config.animation);
-
-  el.setAttribute("data-aos-offset", `${config.offset ?? 120}`);
-  el.setAttribute("data-aos-delay", `${config.delay ?? 0}`);
-  el.setAttribute("data-aos-duration", `${config.duration ?? 400}`);
-  el.setAttribute("data-aos-easing", config.easing || "ease");
-  el.setAttribute("data-aos-anchor-placement", config.easing || "top-bottom");
-
-  el.setAttribute("data-aos-once", `${!!modifiers.once}`);
-  el.setAttribute("data-aos-mirror", `${!!modifiers.mirror}`);
+  const config = binding.value || {};
+  const modifiers = binding.modifiers || {};
+  Object.entries({
+    "data-aos": config.animation,
+    "data-aos-offset": `${config.offset ?? 120}`,
+    "data-aos-delay": `${config.delay ?? 0}`,
+    "data-aos-duration": `${config.duration ?? 400}`,
+    "data-aos-easing": config.easing || "ease",
+    "data-aos-anchor-placement": config.anchorPlacement || "top-bottom",
+    "data-aos-once": `${!!modifiers.once}`,
+    "data-aos-mirror": `${!!modifiers.mirror}`,
+  }).forEach(([key, value]) => el.setAttribute(key, value));
 });
 
 new Vue({


### PR DESCRIPTION
Just minor refactorings. This is so that the `main.js` file does not get polluted with all the definitions over time. I also slightly improved the `v-aos` directive is used on the homepage.