### PR TITLE
Add show password capabilities

### DIFF
--- a/dl4se-website/src/assets/styles/component/clearable-input.sass
+++ b/dl4se-website/src/assets/styles/component/clearable-input.sass
@@ -7,8 +7,12 @@ input
   border-width: 0 0 1px 0!important
 
 .btn
-  @include button-variant($gray-200, $gray-600, $gray-600, $gray-600, $gray-700)
   border-top: 0!important
   border-left: 0!important
   border-right: 0!important
   border-radius: 0!important
+  color: $gray-600!important
+  background-color: $gray-200!important
+
+  &:hover
+    color: $gray-700!important

--- a/dl4se-website/src/assets/styles/component/form-input-password.sass
+++ b/dl4se-website/src/assets/styles/component/form-input-password.sass
@@ -1,0 +1,13 @@
+@import "@/assets/styles/variables"
+@import "@/assets/styles/mixins"
+
+.btn
+  border-top: 0!important
+  border-left: 0!important
+  border-right: 0!important
+  border-radius: 0!important
+  color: $gray-600!important
+  background-color: $gray-200!important
+
+  &:hover
+    color: $gray-700!important

--- a/dl4se-website/src/assets/styles/view/_form-page.sass
+++ b/dl4se-website/src/assets/styles/view/_form-page.sass
@@ -1,5 +1,8 @@
 @import "@/assets/styles/variables"
 
+h1
+  margin-bottom: map-get($spacers, 3)!important
+
 form
   $width: 290px
 

--- a/dl4se-website/src/assets/styles/view/_form-page.sass
+++ b/dl4se-website/src/assets/styles/view/_form-page.sass
@@ -3,7 +3,7 @@
 form
   $width: 290px
 
-  input
+  input, .input-group
     width: $width!important
 
   .bi

--- a/dl4se-website/src/components/FormInputPassword.vue
+++ b/dl4se-website/src/components/FormInputPassword.vue
@@ -1,0 +1,74 @@
+<template>
+  <b-input-group>
+    <b-input
+      :id="id"
+      :name="name"
+      :type="type"
+      :state="state"
+      :disabled="disabled"
+      :autocomplete="autocomplete"
+      v-model.trim="input"
+    />
+    <b-input-group-append>
+      <b-button :pressed.sync="pressed">
+        <b-icon :icon="icon" />
+      </b-button>
+    </b-input-group-append>
+  </b-input-group>
+</template>
+
+<script>
+export default {
+  name: "b-form-input-password",
+  props: {
+    id: {
+      type: String,
+      default: null,
+    },
+    value: String,
+    name: {
+      type: String,
+      default: null,
+    },
+    state: {
+      type: Boolean,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    autocomplete: {
+      type: String,
+      default: "off",
+      validator(value) {
+        const values = ["current-password", "new-password", "off"];
+        return values.includes(value);
+      },
+    },
+  },
+  computed: {
+    input: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit("input", value);
+      },
+    },
+    icon() {
+      return this.pressed ? "eye" : "eye-slash";
+    },
+    type() {
+      return this.pressed ? "text" : "password";
+    },
+  },
+  data() {
+    return {
+      pressed: false,
+    };
+  },
+};
+</script>
+
+<style scoped lang="sass" src="@/assets/styles/component/form-input-password.sass" />

--- a/dl4se-website/src/views/LogInView.vue
+++ b/dl4se-website/src/views/LogInView.vue
@@ -34,10 +34,9 @@
               </label>
               <b-link :to="{ name: 'forgot' }">Forgot your password?</b-link>
             </div>
-            <b-form-input
+            <b-form-input-password
               id="password"
               name="password"
-              type="password"
               autocomplete="current-password"
               v-model.trim="form.password"
               :disabled="submitted"
@@ -69,11 +68,12 @@ import useVuelidate from "@vuelidate/core";
 import { email, required } from "@vuelidate/validators";
 import { password } from "@/validators";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
+import BFormInputPassword from "@/components/FormInputPassword";
 import BFormSubmit from "@/components/FormSubmit";
 
 export default {
   mixins: [bootstrapMixin],
-  components: { BFormSubmit },
+  components: { BFormInputPassword, BFormSubmit },
   computed: {
     target() {
       return this.$route.query.target || "home";

--- a/dl4se-website/src/views/RegisterView.vue
+++ b/dl4se-website/src/views/RegisterView.vue
@@ -29,10 +29,9 @@
               Password
               <b-icon-asterisk font-scale="0.35" shift-v="16" class="text-danger" />
             </template>
-            <b-form-input
+            <b-form-input-password
               id="password"
               name="password"
-              type="password"
               autocomplete="new-password"
               v-model.trim="form.password"
               :disabled="submitted"
@@ -50,10 +49,9 @@
               Confirm Password
               <b-icon-asterisk font-scale="0.35" shift-v="16" class="text-danger" />
             </template>
-            <b-form-input
+            <b-form-input-password
               id="confirm"
               name="confirm"
-              type="password"
               autocomplete="new-password"
               v-model.trim="form.confirm"
               :disabled="submitted"
@@ -120,12 +118,14 @@ import routerMixin from "@/mixins/routerMixin";
 import organisationsMixin from "@/mixins/organisationsMixin";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
 import BFormAutoComplete from "@/components/FormAutoComplete";
+import BFormInputPassword from "@/components/FormInputPassword";
 import BFormSubmit from "@/components/FormSubmit";
 
 export default {
   mixins: [routerMixin, organisationsMixin, bootstrapMixin],
   components: {
     BFormAutoComplete,
+    BFormInputPassword,
     BFormSubmit,
   },
   methods: {

--- a/dl4se-website/src/views/ResetPasswordView.vue
+++ b/dl4se-website/src/views/ResetPasswordView.vue
@@ -9,10 +9,9 @@
               Password
               <b-icon-asterisk font-scale="0.35" shift-v="16" class="text-danger" />
             </template>
-            <b-form-input
+            <b-form-input-password
               id="password"
               name="password"
-              type="password"
               autocomplete="new-password"
               v-model.trim="form.password"
               :disabled="submitted"
@@ -30,10 +29,9 @@
               Confirm Password
               <b-icon-asterisk font-scale="0.35" shift-v="16" class="text-danger" />
             </template>
-            <b-form-input
+            <b-form-input-password
               id="confirm"
               name="confirm"
-              type="password"
               autocomplete="new-password"
               v-model.trim="form.confirm"
               :disabled="submitted"
@@ -70,11 +68,12 @@ import { required, sameAs } from "@vuelidate/validators";
 import { password } from "@/validators";
 import routerMixin from "@/mixins/routerMixin";
 import bootstrapMixin from "@/mixins/bootstrapMixin";
+import BFormInputPassword from "@/components/FormInputPassword";
 import BFormSubmit from "@/components/FormSubmit";
 
 export default {
   mixins: [routerMixin, bootstrapMixin],
-  components: { BFormSubmit },
+  components: { BFormInputPassword, BFormSubmit },
   props: {
     token: String,
   },


### PR DESCRIPTION
Various forms that require password inputs should be able to reveal it at the click of a button. This PR introduces a dedicated component for that.

> [!NOTE]
> The styling of `ClearableInput` was also changed.